### PR TITLE
feat: add an input `workflow`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -44,9 +44,9 @@ inputs:
     description: |
       How to handle changed workflow files.
       This input is used if `app_id` and `app_private_key` are specified.
-      To commit workflow files, the permission `actions:write` is required.
+      To commit workflow files, the permission `workflows:write` is required.
       The following values are available:
-      1. allow - Grant `actions:write` permission when creating an access token
+      1. allow - Grant `workflows:write` permission when creating an access token
       2. deny - Fail if workflow files are changed
       3. ignore - Ignore workflow files
     required: false
@@ -94,8 +94,8 @@ runs:
         fi
         if [ "$WORKFLOW" = allow ]; then
           if echo "$FILES" | grep -qE '^\.github/workflows/'; then
-            echo "::notice:: Grant actions:write permission" >&2
-            echo 'permissions={"contents": "write", "actions": "write"}' >> "$GITHUB_OUTPUT"
+            echo "::notice:: Grant workflows:write permission" >&2
+            echo 'permissions={"contents": "write", "workflows": "write"}' >> "$GITHUB_OUTPUT"
           fi
         fi
         {

--- a/action.yaml
+++ b/action.yaml
@@ -133,7 +133,7 @@ runs:
         MESSAGE: ${{ inputs.commit_message }}
         BRANCH_NAME: ${{ inputs.branch }}
         REPOSITORY: ${{ inputs.repository }}
-        FILES: ${{ steps.files.output.files }}
+        FILES: ${{ steps.files.outputs.files }}
       run: |
         branch=${BRANCH_NAME:-${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}}
         repo=${REPOSITORY:-$GITHUB_REPOSITORY}

--- a/action.yaml
+++ b/action.yaml
@@ -46,7 +46,7 @@ inputs:
       This input is used if `app_id` and `app_private_key` are specified.
       To commit workflow files, the permission `actions:write` is required.
       The following values are available:
-      1. allow - Grant `actions:write` permission when issueing an access token
+      1. allow - Grant `actions:write` permission when creating an access token
       2. deny - Fail if workflow files are changed
       3. ignore - Ignore workflow files
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -100,7 +100,7 @@ runs:
         fi
         {
           echo 'files<<EOF'
-          cat "$FILES"
+          echo "$FILES"
           echo EOF
         } >> "$GITHUB_OUTPUT"
 

--- a/action.yaml
+++ b/action.yaml
@@ -40,6 +40,17 @@ inputs:
       By default, all modified and untracked files are committed.
       git ls-files --modified --others --exclude-standard
     required: false
+  workflow:
+    description: |
+      How to handle changed workflow files.
+      This input is used if `app_id` and `app_private_key` are specified.
+      To commit workflow files, the permission `actions:write` is required.
+      The following values are available:
+      1. allow - Grant `actions:write` permission when issueing an access token
+      2. deny - Fail if workflow files are changed
+      3. ignore - Ignore workflow files
+    required: false
+    default: allow
 runs:
   using: composite
   steps:
@@ -62,6 +73,35 @@ runs:
       env:
         REPOSITORY: ${{ inputs.repository }}
 
+    # List changed files
+    - shell: bash
+      id: files
+      env:
+        FILES: ${{ inputs.files }}
+        WORKFLOW: ${{ inputs.workflow }}
+      run: |
+        echo 'permissions={"contents": "write"}' >> "$GITHUB_OUTPUT"
+        if [ -z "$FILES" ]; then
+          FILES=$(git ls-files --modified --others --exclude-standard)
+          if [ -z "$FILES" ]; then
+            echo "::notice:: No changes" >&2
+            exit 0
+          fi
+        fi
+        if [ "$WORKFLOW" = ignore ]; then
+          FILES=$(echo "$FILES" | grep -vE '^\.github/workflows/')
+        fi
+        if [ "$WORKFLOW" = allow ]; then
+          if echo "$FILES" | grep -qE '^\.github/workflows/'; then
+            echo 'permissions={"contents": "write", "actions": "write"}' >> "$GITHUB_OUTPUT"
+          fi
+        fi
+        {
+          echo 'files<<EOF'
+          cat "$FILES"
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+
     - uses: suzuki-shunsuke/github-token-action@350d7506222e3a0016491abe85b5c4dd475b67d1 # v0.2.1
       id: token
       with:
@@ -69,10 +109,7 @@ runs:
         github_app_id: ${{inputs.app_id}}
         github_app_private_key: ${{inputs.app_private_key}}
         default_github_token: ${{github.token}}
-        github_app_permissions: >-
-          {
-            "contents": "write"
-          }
+        github_app_permissions: ${{steps.files.outputs.permissions}}
         github_app_repositories: >-
           [
             "${{steps.repo_name.outputs.value}}"
@@ -87,21 +124,15 @@ runs:
     # List changed files
     # Commit changes
     - shell: bash
+      if: steps.files.outputs.value != ''
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         AQUA_CONFIG: ${{ steps.aqua_config.outputs.value }}
         MESSAGE: ${{ inputs.commit_message }}
         BRANCH_NAME: ${{ inputs.branch }}
         REPOSITORY: ${{ inputs.repository }}
-        FILES: ${{ inputs.files }}
+        FILES: ${{ steps.files.output.files }}
       run: |
-        if [ -z "$FILES" ]; then
-          FILES=$(git ls-files --modified --others --exclude-standard)
-          if [ -z "$FILES" ]; then
-            echo "[INFO] No changes" >&2
-            exit 0
-          fi
-        fi
         branch=${BRANCH_NAME:-${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}}
         repo=${REPOSITORY:-$GITHUB_REPOSITORY}
         tempfile=$(mktemp)

--- a/action.yaml
+++ b/action.yaml
@@ -126,7 +126,7 @@ runs:
     # List changed files
     # Commit changes
     - shell: bash
-      if: steps.files.outputs.value != ''
+      if: steps.files.outputs.files != ''
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         AQUA_CONFIG: ${{ steps.aqua_config.outputs.value }}

--- a/action.yaml
+++ b/action.yaml
@@ -65,14 +65,6 @@ runs:
       env:
         AQUA_CONFIG: ${{ steps.aqua_config.outputs.value }}
 
-    - shell: bash
-      id: repo_name
-      run: |
-        repo=${REPOSITORY:-$GITHUB_REPOSITORY}
-        echo "value=${repo#*/}" >> "$GITHUB_OUTPUT"
-      env:
-        REPOSITORY: ${{ inputs.repository }}
-
     # List changed files
     - shell: bash
       id: files
@@ -104,7 +96,17 @@ runs:
           echo EOF
         } >> "$GITHUB_OUTPUT"
 
+    - shell: bash
+      id: repo_name
+      if: steps.files.outputs.files != ''
+      run: |
+        repo=${REPOSITORY:-$GITHUB_REPOSITORY}
+        echo "value=${repo#*/}" >> "$GITHUB_OUTPUT"
+      env:
+        REPOSITORY: ${{ inputs.repository }}
+
     - uses: suzuki-shunsuke/github-token-action@350d7506222e3a0016491abe85b5c4dd475b67d1 # v0.2.1
+      if: steps.files.outputs.files != ''
       id: token
       with:
         github_token: ${{inputs.github_token}}
@@ -118,12 +120,12 @@ runs:
           ]
 
     - shell: bash
+      if: steps.files.outputs.files != ''
       run: ghcp -v
       env:
         AQUA_CONFIG: ${{ steps.aqua_config.outputs.value }}
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
 
-    # List changed files
     # Commit changes
     - shell: bash
       if: steps.files.outputs.files != ''

--- a/action.yaml
+++ b/action.yaml
@@ -89,10 +89,12 @@ runs:
           fi
         fi
         if [ "$WORKFLOW" = ignore ]; then
+          echo "::notice:: Ignore workflow files" >&2
           FILES=$(echo "$FILES" | grep -vE '^\.github/workflows/')
         fi
         if [ "$WORKFLOW" = allow ]; then
           if echo "$FILES" | grep -qE '^\.github/workflows/'; then
+            echo "::notice:: Grant actions:write permission" >&2
             echo 'permissions={"contents": "write", "actions": "write"}' >> "$GITHUB_OUTPUT"
           fi
         fi


### PR DESCRIPTION
This pull request adds an input `workflow`.
This input is used if `app_id` and `app_private_key` are specified.

To commit workflow files, the permission `workflows:write` is required.
The following values are available:

1. allow - Grant `workflows:write` permission when issuing an access token
2. deny - Fail if workflow files are changed
3. ignore - Ignore workflow files