### PR TITLE
chore: update Node.js to v24

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -21,4 +21,6 @@ jobs:
       - run: npm run fmt
       - run: pinact run -u README.md
         if: ${{ !github.event.pull_request.head.repo.fork }}
+        env:
+          GITHUB_TOKEN: ${{github.token}}
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ jobs:
       # ...
 
       - name: Push changes to the remote branch
-        uses: suzuki-shunsuke/commit-action@f12e2d628a4ab72dcefe7890ae07e8dbf1e201b9 # v0.1.1
+        uses: suzuki-shunsuke/commit-action@44cc32c01e261a029c0161ff908a3a2895bfc46f # v0.1.2
 ```
 
 commit-action fails if it pushes a commit to `${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}` in `$GITHUB_REPOSITORY`.
@@ -79,7 +79,7 @@ If no change is pushed, commit-action does nothing and exits successfully.
 By default, commit-action pushes a commit to `${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}` in `$GITHUB_REPOSITORY`, but you can change them.
 
 ```yaml
-- uses: suzuki-shunsuke/commit-action@f12e2d628a4ab72dcefe7890ae07e8dbf1e201b9 # v0.1.1
+- uses: suzuki-shunsuke/commit-action@44cc32c01e261a029c0161ff908a3a2895bfc46f # v0.1.2
   with:
     branch: foo
     repository: suzuki-shunsuke/tfcmt
@@ -91,7 +91,7 @@ If a new branch is created, the parent branch is the default branch by default.
 You can specify the paretn branch.
 
 ```yaml
-- uses: suzuki-shunsuke/commit-action@f12e2d628a4ab72dcefe7890ae07e8dbf1e201b9 # v0.1.1
+- uses: suzuki-shunsuke/commit-action@44cc32c01e261a029c0161ff908a3a2895bfc46f # v0.1.2
   with:
     branch: foo-2
     parent_branch: foo
@@ -105,7 +105,7 @@ You can create a GitHub App installation access token and pass it to commit-acti
 Then commit-action creates a GitHub App installation access token with minimum `repositories` and `permissions`.
 
 ```yaml
-- uses: suzuki-shunsuke/commit-action@f12e2d628a4ab72dcefe7890ae07e8dbf1e201b9 # v0.1.1
+- uses: suzuki-shunsuke/commit-action@44cc32c01e261a029c0161ff908a3a2895bfc46f # v0.1.2
   with:
     app_id: ${{secrets.APP_ID}}
     app_private_key: ${{secrets.APP_PRIVATE_KEY}}
@@ -122,7 +122,7 @@ The input `files` is a list of relative paths from `root_dir`.
 e.g.
 
 ```yaml
-- uses: suzuki-shunsuke/commit-action@f12e2d628a4ab72dcefe7890ae07e8dbf1e201b9 # v0.1.1
+- uses: suzuki-shunsuke/commit-action@44cc32c01e261a029c0161ff908a3a2895bfc46f # v0.1.2
   with:
     files: |
       README.md
@@ -135,7 +135,7 @@ e.g.
 When the input `fail_on_self_push` is set to `false` (the default is `true`), the action succeeds in this case.
 
 ```yaml
-- uses: suzuki-shunsuke/commit-action@f12e2d628a4ab72dcefe7890ae07e8dbf1e201b9 # v0.1.1
+- uses: suzuki-shunsuke/commit-action@44cc32c01e261a029c0161ff908a3a2895bfc46f # v0.1.2
   with:
     fail_on_self_push: false # continue without failing when self-pushing
 ```
@@ -158,7 +158,7 @@ The following values are available:
 1. `ignore` - Ignore workflow files
 
 ```yaml
-- uses: suzuki-shunsuke/commit-action@f12e2d628a4ab72dcefe7890ae07e8dbf1e201b9 # v0.1.1
+- uses: suzuki-shunsuke/commit-action@44cc32c01e261a029c0161ff908a3a2895bfc46f # v0.1.2
   with:
     workflow: ignore # allow (default), deny
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -91,6 +91,6 @@ outputs:
     description: "Pushed Same Target"
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"
   post: "dist/index.js"


### PR DESCRIPTION
BREAKING CHANGE:

Node.js v24 is required.