### PR TITLE
feat: support empty commits

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,9 +29,9 @@ inputs:
     required: false
   commit_message:
     description: |
-      Commit message
+      Commit message.
+      If empty, defaults to "empty commit" when empty_commit is true, otherwise "commit changes".
     required: false
-    default: "commit changes"
   branch:
     description: |
       A Pushed branch.

--- a/action.yaml
+++ b/action.yaml
@@ -81,6 +81,11 @@ inputs:
       Set to false to avoid failing and check outputs instead.
     required: false
     default: "true"
+  empty_commit:
+    description: |
+      If true, the action creates an empty commit when no files are changed.
+    required: false
+    default: "false"
 
 outputs:
   sha:

--- a/src/run.ts
+++ b/src/run.ts
@@ -72,12 +72,15 @@ export const main = async () => {
     repo = r;
   }
   const token = await getToken(owner, repo, permissions);
+  const commitMessage =
+    core.getInput("commit_message") ||
+    (emptyCommit ? "empty commit" : "commit changes");
   core.info(
     `creating a commit: ${JSON.stringify({
       owner: owner,
       repo: repo,
       branch: branch,
-      message: core.getInput("commit_message") || "Commit changes",
+      message: commitMessage,
       files: files,
       emptyCommit,
       rootDir: core.getInput("root_dir"),
@@ -90,7 +93,7 @@ export const main = async () => {
     owner: owner,
     repo: repo,
     branch: branch,
-    message: core.getInput("commit_message") || "Commit changes",
+    message: commitMessage,
     files: files,
     empty: emptyCommit,
     rootDir: core.getInput("root_dir"),

--- a/src/run.ts
+++ b/src/run.ts
@@ -25,10 +25,15 @@ export const main = async () => {
     contents: "write",
   };
 
-  let files = await getFiles();
-  if (files.length === 0) {
-    core.notice("No changes");
-    return;
+  const emptyCommit = core.getBooleanInput("empty_commit");
+
+  let files: string[] = [];
+  if (!emptyCommit) {
+    files = await getFiles();
+    if (files.length === 0 && !emptyCommit) {
+      core.notice("No changes");
+      return;
+    }
   }
   const workflowOption = core.getInput("workflow");
   if (workflowOption === "ignore") {
@@ -74,6 +79,7 @@ export const main = async () => {
       branch: branch,
       message: core.getInput("commit_message") || "Commit changes",
       files: files,
+      emptyCommit,
       rootDir: core.getInput("root_dir"),
       baseBranch: core.getInput("parent_branch"),
       deleteIfNotExist: true,
@@ -86,6 +92,7 @@ export const main = async () => {
     branch: branch,
     message: core.getInput("commit_message") || "Commit changes",
     files: files,
+    empty: emptyCommit,
     rootDir: core.getInput("root_dir"),
     baseBranch: core.getInput("parent_branch"),
     deleteIfNotExist: true,


### PR DESCRIPTION
Close #214

Added the boolean input `empty_commit`.
By default, it's false.
If it's true, this action creates an empty commit.

## Test

https://github.com/szksh-lab-2/test-github-action/pull/377/changes/e93e21d2a15f17513416c4662cc762d0ea6475fd

```yaml
      - uses: suzuki-shunsuke/commit-action@pr/370
        with:
          empty_commit: true
```