### PR TITLE
feat: support force push

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -86,6 +86,11 @@ inputs:
       If true, the action creates an empty commit when no files are changed.
     required: false
     default: "false"
+  force_push:
+    description: |
+      If true, the action pushes a commit forcibly.
+    required: false
+    default: "false"
 
 outputs:
   sha:

--- a/src/run.ts
+++ b/src/run.ts
@@ -75,6 +75,7 @@ export const main = async () => {
   const commitMessage =
     core.getInput("commit_message") ||
     (emptyCommit ? "empty commit" : "commit changes");
+  const forcePush = core.getBooleanInput("force_push");
   core.info(
     `creating a commit: ${JSON.stringify({
       owner: owner,
@@ -83,6 +84,7 @@ export const main = async () => {
       message: commitMessage,
       files: files,
       emptyCommit,
+      forcePush,
       rootDir: core.getInput("root_dir"),
       baseBranch: core.getInput("parent_branch"),
       deleteIfNotExist: true,
@@ -96,6 +98,7 @@ export const main = async () => {
     message: commitMessage,
     files: files,
     empty: emptyCommit,
+    forcePush,
     rootDir: core.getInput("root_dir"),
     baseBranch: core.getInput("parent_branch"),
     deleteIfNotExist: true,

--- a/src/run.ts
+++ b/src/run.ts
@@ -76,6 +76,8 @@ export const main = async () => {
     core.getInput("commit_message") ||
     (emptyCommit ? "empty commit" : "commit changes");
   const forcePush = core.getBooleanInput("force_push");
+  const rootDir = core.getInput("root_dir");
+  const baseBranch = core.getInput("parent_branch");
   core.info(
     `creating a commit: ${JSON.stringify({
       owner: owner,
@@ -85,8 +87,8 @@ export const main = async () => {
       files: files,
       emptyCommit,
       forcePush,
-      rootDir: core.getInput("root_dir"),
-      baseBranch: core.getInput("parent_branch"),
+      rootDir,
+      baseBranch,
       deleteIfNotExist: true,
     })}`,
   );
@@ -99,8 +101,8 @@ export const main = async () => {
     files: files,
     empty: emptyCommit,
     forcePush,
-    rootDir: core.getInput("root_dir"),
-    baseBranch: core.getInput("parent_branch"),
+    rootDir,
+    baseBranch,
     deleteIfNotExist: true,
     logger: {
       info: core.info,


### PR DESCRIPTION
Close #216

Added the boolean input `force_push`.
By default, it's false.
If it's true, this action pushes a commit forcibly.

## Test

```yaml
      - uses: suzuki-shunsuke/commit-action@pr/371
        with:
          force_push: true
          parent_branch: main
```