### PR TITLE
feat: revoke GitHub App token in main step instead of post step

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -113,4 +113,3 @@ outputs:
 runs:
   using: "node24"
   main: "dist/index.js"
-  post: "dist/index.js"

--- a/src/run.ts
+++ b/src/run.ts
@@ -68,48 +68,27 @@ export const main = async () => {
   const baseBranch = core.getInput("parent_branch");
   const noParent = core.getBooleanInput("orphan");
   const useBaseTree = core.getBooleanInput("use_base_tree");
-  core.info(
-    `creating a commit: ${JSON.stringify({
-      owner: owner,
-      repo: repo,
-      branch: branch,
-      message: commitMessage,
-      files: files,
-      emptyCommit,
-      forcePush,
-      rootDir,
-      baseBranch,
-      deleteIfNotExist: true,
-      noParent,
-      useBaseTree,
-    })}`,
-  );
-  let result: commit.Result | undefined;
-  let appToken: githubAppToken.Token | undefined;
-  try {
-    const got = await getToken(owner, repo, permissions);
-    appToken = got.appToken;
-    const octokit = github.getOctokit(got.token);
-    result = await commit.createCommit(octokit, {
-      owner: owner,
-      repo: repo,
-      branch: branch,
-      message: commitMessage,
-      files: files,
-      empty: emptyCommit,
-      forcePush,
-      rootDir,
-      baseBranch,
-      deleteIfNotExist: true,
-      noParent,
-      useBaseTree,
-      logger: {
-        info: core.info,
-      },
-    });
-  } finally {
-    await revokeToken(appToken);
-  }
+  const param: Omit<commit.Options, "logger"> = {
+    owner: owner,
+    repo: repo,
+    branch: branch,
+    message: commitMessage,
+    files: files,
+    empty: emptyCommit,
+    forcePush,
+    rootDir,
+    baseBranch,
+    deleteIfNotExist: true,
+    noParent,
+    useBaseTree,
+  };
+  core.info(`creating a commit: ${JSON.stringify(param)}`);
+  const result = await createCommit(permissions, {
+    ...param,
+    logger: {
+      info: core.info,
+    },
+  });
   const pushed = result?.commit.sha !== undefined && result?.commit.sha !== "";
   core.setOutput("sha", result?.commit.sha || "");
   core.setOutput("pushed", pushed);
@@ -125,6 +104,21 @@ export const main = async () => {
       return;
     }
     core.notice("a commit was pushed");
+  }
+};
+
+const createCommit = async (
+  permissions: githubAppToken.Permissions,
+  opts: commit.Options,
+): Promise<commit.Result | undefined> => {
+  let appToken: githubAppToken.Token | undefined;
+  try {
+    const got = await getToken(opts.owner, opts.repo, permissions);
+    appToken = got.appToken;
+    const octokit = github.getOctokit(got.token);
+    return await commit.createCommit(octokit, opts);
+  } finally {
+    await revokeToken(appToken);
   }
 };
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,7 +4,10 @@ import * as github from "@actions/github";
 import * as commit from "@suzuki-shunsuke/commit-ts";
 import * as githubAppToken from "@suzuki-shunsuke/github-app-token";
 
-let appToken: githubAppToken.Token | undefined;
+type GetTokenResult = {
+  token: string;
+  appToken?: githubAppToken.Token;
+};
 
 export const main = async () => {
   const permissions: githubAppToken.Permissions = {
@@ -82,9 +85,11 @@ export const main = async () => {
     })}`,
   );
   let result: commit.Result | undefined;
+  let appToken: githubAppToken.Token | undefined;
   try {
-    const token = await getToken(owner, repo, permissions);
-    const octokit = github.getOctokit(token);
+    const got = await getToken(owner, repo, permissions);
+    appToken = got.appToken;
+    const octokit = github.getOctokit(got.token);
     result = await commit.createCommit(octokit, {
       owner: owner,
       repo: repo,
@@ -145,10 +150,10 @@ const getToken = async (
   owner: string,
   repo: string,
   permissions: githubAppToken.Permissions,
-): Promise<string> => {
+): Promise<GetTokenResult> => {
   const token = core.getInput("github_token");
   if (token) {
-    return token;
+    return { token };
   }
   const appId = core.getInput("app_id");
   const appPrivateKey = core.getInput("app_private_key");
@@ -163,7 +168,7 @@ const getToken = async (
         permissions: permissions,
       })}`,
     );
-    appToken = await githubAppToken.create({
+    const appToken = await githubAppToken.create({
       appId: appId,
       privateKey: appPrivateKey,
       owner: owner,
@@ -171,12 +176,12 @@ const getToken = async (
       permissions: permissions,
     });
     core.setSecret(appToken.token);
-    return appToken.token;
+    return { token: appToken.token, appToken };
   }
   if (appPrivateKey) {
     throw new Error("app_id is required when app_private_key is provided");
   }
-  return core.getInput("default_github_token");
+  return { token: core.getInput("default_github_token") };
 };
 
 const getFiles = async (): Promise<string[]> => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,23 +4,9 @@ import * as github from "@actions/github";
 import * as commit from "@suzuki-shunsuke/commit-ts";
 import * as githubAppToken from "@suzuki-shunsuke/github-app-token";
 
-export const main = async () => {
-  if (core.getState("post")) {
-    const token = core.getState("token");
-    const expiresAt = core.getState("expires_at");
-    if (token) {
-      if (expiresAt && githubAppToken.hasExpired(expiresAt)) {
-        core.info("GitHub App token has already expired");
-        return;
-      }
-      // This is post-cleanup: revoke the token created during main execution
-      core.info("Revoking GitHub App token");
-      return githubAppToken.revoke(token);
-    }
-    return;
-  }
-  core.saveState("post", "true");
+let appToken: githubAppToken.Token | undefined;
 
+export const main = async () => {
   const permissions: githubAppToken.Permissions = {
     contents: "write",
   };
@@ -71,7 +57,6 @@ export const main = async () => {
     owner = o;
     repo = r;
   }
-  const token = await getToken(owner, repo, permissions);
   const commitMessage =
     core.getInput("commit_message") ||
     (emptyCommit ? "empty commit" : "commit changes");
@@ -96,24 +81,30 @@ export const main = async () => {
       useBaseTree,
     })}`,
   );
-  const octokit = github.getOctokit(token);
-  const result = await commit.createCommit(octokit, {
-    owner: owner,
-    repo: repo,
-    branch: branch,
-    message: commitMessage,
-    files: files,
-    empty: emptyCommit,
-    forcePush,
-    rootDir,
-    baseBranch,
-    deleteIfNotExist: true,
-    noParent,
-    useBaseTree,
-    logger: {
-      info: core.info,
-    },
-  });
+  let result: commit.Result | undefined;
+  try {
+    const token = await getToken(owner, repo, permissions);
+    const octokit = github.getOctokit(token);
+    result = await commit.createCommit(octokit, {
+      owner: owner,
+      repo: repo,
+      branch: branch,
+      message: commitMessage,
+      files: files,
+      empty: emptyCommit,
+      forcePush,
+      rootDir,
+      baseBranch,
+      deleteIfNotExist: true,
+      noParent,
+      useBaseTree,
+      logger: {
+        info: core.info,
+      },
+    });
+  } finally {
+    await revokeToken(appToken);
+  }
   const pushed = result?.commit.sha !== undefined && result?.commit.sha !== "";
   core.setOutput("sha", result?.commit.sha || "");
   core.setOutput("pushed", pushed);
@@ -129,6 +120,24 @@ export const main = async () => {
       return;
     }
     core.notice("a commit was pushed");
+  }
+};
+
+const revokeToken = async (appToken: githubAppToken.Token | undefined) => {
+  if (!appToken) {
+    return;
+  }
+  if (appToken.expiresAt && githubAppToken.hasExpired(appToken.expiresAt)) {
+    core.info("GitHub App token has already expired");
+    return;
+  }
+  core.info("Revoking GitHub App token");
+  try {
+    await githubAppToken.revoke(appToken.token);
+  } catch (e) {
+    core.warning(
+      `failed to revoke GitHub App token: ${e instanceof Error ? e.message : String(e)}`,
+    );
   }
 };
 
@@ -154,7 +163,7 @@ const getToken = async (
         permissions: permissions,
       })}`,
     );
-    const appToken = await githubAppToken.create({
+    appToken = await githubAppToken.create({
       appId: appId,
       privateKey: appPrivateKey,
       owner: owner,
@@ -162,8 +171,6 @@ const getToken = async (
       permissions: permissions,
     });
     core.setSecret(appToken.token);
-    core.saveState("token", appToken.token);
-    core.saveState("expires_at", appToken.expiresAt);
     return appToken.token;
   }
   if (appPrivateKey) {


### PR DESCRIPTION
## Summary

Move installation access token revocation from the action's `post` step into a `try/finally` block in the main step, and refactor the surrounding code for clearer ownership of the token lifecycle.

### Why

- **Security**: Minimize the lifetime of the GitHub App installation access token. Revoke it as soon as it is no longer needed, rather than waiting for the post step.
- **Simplicity**: Remove the post-step round-trip (saving/loading state, re-invoking the bundle), reducing overhead and making the action's logs more linear and easier to follow.

## Changes

### `action.yaml`
- Drop `post: "dist/index.js"`. The action no longer needs a post step.

### `src/run.ts`

**Token lifecycle**
- Remove the `core.getState("post")` branch and the `core.saveState("post"|"token"|"expires_at", ...)` calls. State persistence between main and post is no longer needed.
- Introduce a `createCommit(permissions, opts)` helper that owns a `try/finally` around `commit.createCommit`. The `finally` block calls `revokeToken` so the token is revoked even if commit creation throws.
- `revokeToken` is `async` and awaits `githubAppToken.revoke(...)`. Without `await` the Node process could exit before the revoke HTTP request completes, defeating the purpose of immediate revocation. A failure to revoke is logged via `core.warning` rather than rethrown, so it does not mask the original error from the `try` block.

**`getToken` API**
- `getToken` now returns `{ token: string; appToken?: githubAppToken.Token }` (typed as `GetTokenResult`) instead of just a `string`. The caller uses `appToken` to drive `revokeToken` in the `finally`. This avoids module-level mutable state and makes the side effect explicit.
- `github_token` and `default_github_token` paths return `{ token }` only (no `appToken`), so they are no-ops for revocation.

**Param object**
- Extract the commit options into a `param` object typed as `Omit<commit.Options, \"logger\">`. The explicit type annotation enables TypeScript's excess property check, so any future typo (e.g. `emptyCommit` instead of `empty`) is caught at compile time. This object is then logged and spread into the `createCommit` call together with the `logger`.

## Trade-off

GitHub Actions guarantees that `post:` steps run on cancellation (within timeout). With `try/finally`, revocation depends on Node receiving SIGTERM cleanly. Since installation tokens auto-expire within an hour, this is an acceptable trade-off for the security and simplicity gains.

## Test plan

- [ ] CI passes on this PR
- [ ] In a workflow that uses `app_id` / `app_private_key`, confirm logs contain \`Revoking GitHub App token\` and that the action exits successfully
- [ ] In a workflow that uses `github_token` / `default_github_token`, confirm no revoke log is emitted
- [ ] Trigger a failure inside `commit.createCommit` (e.g. invalid branch) and confirm the original error is reported while the token is still revoked
- [ ] Confirm `empty_commit: true` still produces an empty commit (covered by the typed `param` change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)